### PR TITLE
Implement /save_local_file command

### DIFF
--- a/chat_commands.js
+++ b/chat_commands.js
@@ -1,0 +1,69 @@
+// chat_commands.js
+// Обработчик команд из чата
+const memory = require('./memory');
+const memory_mode = require('./memory_mode');
+
+/**
+ * Разбирает строку с аргументами формата key="value"
+ * Аргументы:
+ *     text (string): текст команды
+ * Возвращает:
+ *     Object — пары ключ-значение
+ */
+function parse_arguments(text) {
+  const args = {};
+  const regex = /(\w+)="([\s\S]*?)"/g;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    args[match[1]] = match[2];
+  }
+  return args;
+}
+
+/**
+ * Обрабатывает команду сохранения локального файла
+ * Аргументы:
+ *     message (string): текст команды
+ *     userId (string): идентификатор пользователя
+ * Возвращает:
+ *     boolean — была ли обработана команда
+ */
+function handle_save_local_file(message, userId = 'user') {
+  if (!message.startsWith('/save_local_file')) {
+    return false;
+  }
+  const params = parse_arguments(message);
+  const filename = params.name;
+  const content = params.content || '';
+  if (!filename) {
+    console.log('❌ Ошибка: не указано имя файла');
+    return true;
+  }
+  try {
+    if (memory_mode.repo_state.active) {
+      memory_mode.saveMemoryWithIndex({
+        repo: memory_mode.repo_state.repo,
+        token: memory_mode.repo_state.token,
+        filename,
+        content,
+        userId,
+        type: memory_mode.repo_state.type
+      });
+      console.log(`✅ Успешно сохранено: ${filename}`);
+    } else if (memory.memory_state.memory_path) {
+      const savedPath = memory.writeMemoryFile(filename, content);
+      console.log(`✅ Успешно сохранено: ${savedPath}`);
+    } else {
+      console.log('❌ Ошибка: не выбран режим памяти');
+    }
+  } catch (err) {
+    console.log('❌ Ошибка: не удалось сохранить файл');
+  }
+  return true;
+}
+
+module.exports = {
+  handle_save_local_file
+};
+
+// Модуль предназначен для разбора команд из чата и их выполнения.

--- a/memory.js
+++ b/memory.js
@@ -68,11 +68,33 @@ function getCurrentPlan() {
   return 'План отсутствует';
 }
 
+/**
+ * Сохраняет содержимое в файл выбранной памяти
+ * Аргументы:
+ *     filename (string): имя файла
+ *     content (string): содержимое для записи
+ * Возвращает:
+ *     string — полный путь сохранённого файла
+ */
+function writeMemoryFile(filename, content) {
+  if (!memory_state.memory_path) {
+    throw new Error('Память не настроена');
+  }
+  const dirPath = path.join(memory_state.memory_path, 'memory');
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+  const filePath = path.join(dirPath, filename);
+  fs.writeFileSync(filePath, content, 'utf8');
+  return filePath;
+}
+
 module.exports = {
   memory_state,
   setLocalMemoryBasePath,
   setMemoryFolder,
-  getCurrentPlan
+  getCurrentPlan,
+  writeMemoryFile
 };
 
 // Этот модуль хранит и обновляет данные о локальной памяти.

--- a/memory_mode.js
+++ b/memory_mode.js
@@ -28,9 +28,29 @@ function switchMemoryRepo(type = 'github', repo, token) {
   repo_state.active = true;
 }
 
+/**
+ * Сохраняет файл памяти в удалённый репозиторий
+ * Аргументы:
+ *     options (Object): параметры сохранения
+ *         repo (string): репозиторий
+ *         token (string): токен
+ *         filename (string): имя файла
+ *         content (string): содержимое
+ *         userId (string): идентификатор пользователя
+ *         type (string): тип репозитория
+ * Возвращает:
+ *     boolean — результат операции (заглушка)
+ */
+function saveMemoryWithIndex(options) {
+  // Заглушка для сохранения в GitHub
+  console.log(`Сохранение файла ${options.filename} в репозитории ${options.repo}`);
+  return true;
+}
+
 module.exports = {
   repo_state,
-  switchMemoryRepo
+  switchMemoryRepo,
+  saveMemoryWithIndex
 };
 
 // Модуль описывает подключение к GitHub. В дальнейшем здесь может быть


### PR DESCRIPTION
## Summary
- add function `writeMemoryFile` for local saves
- add stub `saveMemoryWithIndex` for github mode
- create `chat_commands.js` to parse `/save_local_file` command

## Testing
- `node - <<'NODE'
const memory=require('./memory');
const cmd=require('./chat_commands');
memory.setLocalMemoryBasePath('./tmp');
require('fs').mkdirSync('./tmp/project', {recursive: true});
memory.setMemoryFolder('project');
cmd.handle_save_local_file('/save_local_file name="demo.txt" content="demo"');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68651ff838208323ad29ba13c543cd55