### PR TITLE
Implement local file loading command

### DIFF
--- a/chat_commands.js
+++ b/chat_commands.js
@@ -62,8 +62,40 @@ function handle_save_local_file(message, userId = 'user') {
   return true;
 }
 
+/**
+ * Обрабатывает команду загрузки локального файла
+ * Аргументы:
+ *     message (string): текст команды
+ * Возвращает:
+ *     boolean — была ли обработана команда
+ */
+async function handle_load_local_file(message) {
+  if (!message.startsWith('/load_local_file')) {
+    return false;
+  }
+  const params = parse_arguments(message);
+  const filename = params.name;
+  if (!filename) {
+    console.log('❌ Ошибка: не указано имя файла');
+    return true;
+  }
+  if (memory_mode.repo_state.active) {
+    console.log('❗ Активен GitHub-режим. Загрузка из локального файла невозможна.');
+    return true;
+  }
+  try {
+    const content = await memory.readMemoryFile(filename);
+    const prepared = content.replace(/\\n/g, '\n');
+    console.log(`📤 Загружено: ${filename}\n---\n${prepared}`);
+  } catch (err) {
+    console.log(`❌ Файл ${filename} не найден или недоступен.`);
+  }
+  return true;
+}
+
 module.exports = {
-  handle_save_local_file
+  handle_save_local_file,
+  handle_load_local_file
 };
 
 // Модуль предназначен для разбора команд из чата и их выполнения.

--- a/memory.js
+++ b/memory.js
@@ -89,12 +89,32 @@ function writeMemoryFile(filename, content) {
   return filePath;
 }
 
+/**
+ * Читает содержимое файла из выбранной памяти
+ * Аргументы:
+ *     filename (string): имя файла
+ * Возвращает:
+ *     Promise<string> — содержимое файла
+ */
+async function readMemoryFile(filename) {
+  if (!memory_state.memory_path) {
+    throw new Error('Память не настроена');
+  }
+  const filePath = path.join(memory_state.memory_path, 'memory', filename);
+  try {
+    return await fs.promises.readFile(filePath, 'utf8');
+  } catch (err) {
+    throw new Error('Файл не найден');
+  }
+}
+
 module.exports = {
   memory_state,
   setLocalMemoryBasePath,
   setMemoryFolder,
   getCurrentPlan,
-  writeMemoryFile
+  writeMemoryFile,
+  readMemoryFile
 };
 
 // Этот модуль хранит и обновляет данные о локальной памяти.


### PR DESCRIPTION
## Summary
- add `readMemoryFile` helper for reading stored files
- support `/load_local_file` chat command

## Testing
- `node - <<'NODE'
const memory = require('./memory');
const chat = require('./chat_commands');

memory.setLocalMemoryBasePath('/tmp/memtest');
memory.setMemoryFolder('project1');
chat.handle_load_local_file('/load_local_file name="test.md"').then(()=>{})
NODE`
- `node - <<'NODE'
const memory = require('./memory');
const chat = require('./chat_commands');
const memory_mode = require('./memory_mode');

memory_mode.repo_state.active = true;
chat.handle_load_local_file('/load_local_file name="test.md"').then(()=>{})
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68655792f6a88323a25e23bb4cc5e03b