### PR TITLE
Implement memory mode switch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ sofia-desktop-agent/
     - /set_local_path path="..." — указание папки памяти
     - /set_memory_folder name="..." — переключение проекта
     - /switch_memory_repo type=local path="..." — смена источника памяти
+    - /switch_memory_mode mode=local|github — выбор активного режима
 
 ## Разработка
 

--- a/console_interface.js
+++ b/console_interface.js
@@ -105,7 +105,7 @@ function show_plan() {
  * Отображает текущее состояние памяти
  */
 function show_status() {
-  const type = memory_mode.repo_state.active ? memory_mode.repo_state.type : 'Локальная';
+  const type = memory_mode.current_mode === 'github' ? 'github' : 'Локальная';
   console.log(chalk.yellow(`Активная память: ${type}`));
   console.log(chalk.yellow(`Путь: ${memory.memory_state.memory_path || 'не задан'}`));
 }

--- a/memory_mode.js
+++ b/memory_mode.js
@@ -13,6 +13,12 @@ const repo_state = {
 };
 
 /**
+ * Текущий активный режим памяти
+ * @type {string}
+ */
+let current_mode = 'local';
+
+/**
  * Подключает удалённую память через токен и ссылку на репозиторий
  * Аргументы:
  *     token (string): персональный токен GitHub
@@ -49,6 +55,7 @@ function saveMemoryWithIndex(options) {
 
 module.exports = {
   repo_state,
+  current_mode,
   switchMemoryRepo,
   saveMemoryWithIndex
 };


### PR DESCRIPTION
## Summary
- extend argument parser to accept non-quoted values
- add `current_mode` state and export it from `memory_mode`
- implement `/switch_memory_mode` command
- adapt other commands to check new state
- show active mode in the console interface
- document the new command

## Testing
- `node -e "require('./chat_commands.js');"`
- `node -e "require('./memory_mode'); require('./memory');"`

------
https://chatgpt.com/codex/tasks/task_e_68655c2390b88323930fb2eb0baa56e2