### PR TITLE
Add basic express API server

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+require('./src/api');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "sofia-desktop-agent",
+  "version": "1.0.0",
+  "description": "Минимальное кроссплатформенное CLI-приложение на Node.js, выполняющее роль моста между AI-ассистентом София и локальной файловой системой пользователя. Позволяет обмениваться данными памяти между чатом и компьютером без необходимости установки самого плагина.",
+  "main": "chat_commands.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+const PORT = 4465;
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Sofia API is running.');
+});
+
+app.listen(PORT, () => {
+  console.log(`\uD83D\uDFE2 Sofia API started on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- initialize package.json and note express/cors dependencies
- start Express server in `src/api.js`
- launch API from new `index.js`

## Testing
- `node index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6865668ce20083238c3648a4fec2eb7e