### PR TITLE
Add memory file read API

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,12 @@
 const express = require('express');
 const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
+
+// Конфигурация API
+const config = {
+  memoryPath: './memory'
+};
 
 const app = express();
 const PORT = 4465;
@@ -9,6 +16,36 @@ app.use(express.json());
 
 app.get('/', (req, res) => {
   res.send('Sofia API is running.');
+});
+
+/**
+ * Читает указанный файл из папки памяти
+ * Запрос: GET /read?file=filename.md
+ */
+app.get('/read', (req, res) => {
+  const filename = req.query.file;
+  if (!filename) {
+    return res.status(400).send('Missing file parameter');
+  }
+
+  const memory_path = path.resolve(config.memoryPath || './memory');
+  const file_path = path.resolve(memory_path, filename);
+
+  if (!file_path.startsWith(memory_path)) {
+    return res.status(400).send('Invalid file path');
+  }
+
+  // Проверяем существование файла
+  if (!fs.existsSync(file_path)) {
+    return res.status(404).send('File not found');
+  }
+
+  try {
+    const content = fs.readFileSync(file_path, 'utf8');
+    return res.send(content);
+  } catch (err) {
+    return res.status(500).send('Unable to read file');
+  }
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- extend API server with file reading route
- provide config for memoryPath

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68656841bffc8323a66ba68c1ab00a20