### PR TITLE
Implement file saving API route

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -48,6 +48,37 @@ app.get('/read', (req, res) => {
   }
 });
 
+/**
+ * Создаёт или обновляет файл в папке памяти
+ * Запрос: POST /write { file: "name.md", content: "..." }
+ */
+app.post('/write', (req, res) => {
+  const { file, content } = req.body;
+  // проверяем наличие параметров
+  if (!file || !content) {
+    return res.status(400).send('Missing file or content');
+  }
+  // базовая проверка имени файла
+  if (file.includes('..') || file.includes('/') || file.includes('\\')) {
+    return res.status(400).send('Invalid filename');
+  }
+
+  const memory_path = path.resolve(config.memoryPath || './memory');
+  const file_path = path.join(memory_path, file);
+
+  if (!file_path.startsWith(memory_path)) {
+    return res.status(400).send('Invalid filename');
+  }
+
+  try {
+    fs.mkdirSync(memory_path, { recursive: true });
+    fs.writeFileSync(file_path, content, 'utf8');
+    return res.send('File saved successfully');
+  } catch (err) {
+    return res.status(500).send('Unable to save file');
+  }
+});
+
 app.listen(PORT, () => {
   console.log(`\uD83D\uDFE2 Sofia API started on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- create POST `/write` endpoint to save or update memory files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865693048108323ba9a22014e8e6564