### PR TITLE
Add local memory API support

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const CONFIG_FILE = path.join(__dirname, 'config.local.json');
 
-const config = { memoryPath: '' };
+const config = { memoryPath: '', memoryMode: 'local' };
 
 function load() {
   if (fs.existsSync(CONFIG_FILE)) {
@@ -13,17 +13,26 @@ function load() {
       if (json && typeof json.memoryPath === 'string') {
         config.memoryPath = json.memoryPath;
       }
+      if (json && typeof json.memoryMode === 'string') {
+        config.memoryMode = json.memoryMode;
+      }
     } catch (err) {
       console.error('Failed to read config:', err.message);
     }
   } else if (process.env.LOCAL_MEMORY_PATH) {
     config.memoryPath = process.env.LOCAL_MEMORY_PATH;
+    if (process.env.MEMORY_MODE) {
+      config.memoryMode = process.env.MEMORY_MODE;
+    }
   }
 }
 
 function save() {
   try {
-    fs.writeFileSync(CONFIG_FILE, JSON.stringify({ memoryPath: config.memoryPath }, null, 2));
+    fs.writeFileSync(
+      CONFIG_FILE,
+      JSON.stringify({ memoryPath: config.memoryPath, memoryMode: config.memoryMode }, null, 2)
+    );
   } catch (err) {
     console.error('Failed to write config:', err.message);
   }
@@ -34,11 +43,20 @@ function setMemoryPath(p) {
   save();
 }
 
+function setMemoryMode(m) {
+  config.memoryMode = m;
+  save();
+}
+
 load();
 
 module.exports = {
   get memoryPath() {
     return config.memoryPath;
   },
-  setMemoryPath
+  get memoryMode() {
+    return config.memoryMode;
+  },
+  setMemoryPath,
+  setMemoryMode
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const config = require('./config');
 const memory = require('./memory');
+const memory_mode = require('./memory_mode');
 
 if (config.memoryPath) {
   try {
@@ -11,6 +12,10 @@ if (config.memoryPath) {
   } catch (err) {
     console.error('Failed to init memory path:', err.message);
   }
+}
+
+if (config.memoryMode) {
+  memory_mode.current_mode = config.memoryMode;
 }
 
 require('./src/api');


### PR DESCRIPTION
## Summary
- log all incoming requests
- support switching memory repository via API
- extend configuration with memory mode
- read config on startup to set memory mode
- add saveMemoryWithIndex and listFiles helpers for local memory
- expose new local memory endpoints for saving, listing and loading

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "require('./src/api')"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6865a19b15448323a64c0a6411356ac2