### PR TITLE
Rename API route for switching memory mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ sofia-desktop-agent/
 - Формировать команды в формате:
     - /set_local_path path="..." — указание папки памяти
     - /set_memory_folder name="..." — переключение проекта
-    - /switch_memory_repo type=local path="..." — смена источника памяти
-    - /switch_memory_mode mode=local|github — выбор активного режима
+    - /switch_memory_mode mode=local|github — смена источника памяти
     - /load_memory filename="..." — загрузка файла памяти
 
 ## Разработка

--- a/src/api.js
+++ b/src/api.js
@@ -203,7 +203,7 @@ app.post('/set_local_path', (req, res) => {
 /**
  * Переключает режим памяти
  */
-app.post('/switch_memory_repo', (req, res) => {
+function switchMemoryModeHandler(req, res) {
   const { type } = req.body;
   if (!type) {
     return res.status(400).send('Missing type');
@@ -213,10 +213,13 @@ app.post('/switch_memory_repo', (req, res) => {
     memory_mode.current_mode = type;
     return res.json({ success: true, mode: type });
   } catch (err) {
-    console.error('switch_memory_repo:', err.message);
+    console.error('switch_memory_mode:', err.message);
     return res.status(500).json({ error: err.message });
   }
-});
+}
+
+app.post('/switch_memory_mode', switchMemoryModeHandler);
+app.post('/switch_memory_repo', switchMemoryModeHandler);
 
 /**
  * Сохраняет токен


### PR DESCRIPTION
## Summary
- add `/switch_memory_mode` route and keep `/switch_memory_repo` as alias
- update README command list

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68663e8162d88323bf972bbdeb873757