### PR TITLE
Improve memory path validation

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -51,7 +51,14 @@ function resolveMemoryPath(filename) {
  */
 function setLocalMemoryBasePath(folder) {
   const resolved = path.resolve(folder);
-  fs.accessSync(resolved, fs.constants.R_OK | fs.constants.W_OK);
+  try {
+    fs.accessSync(resolved, fs.constants.R_OK | fs.constants.W_OK);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error('Директория не найдена');
+    }
+    throw new Error('Путь недоступен');
+  }
   memory_state.base_path = resolved;
   // обновляем полный путь если уже выбрана папка проекта
   if (memory_state.folder) {
@@ -66,7 +73,14 @@ function setLocalMemoryBasePath(folder) {
  */
 function setMemoryPath(folder) {
   const resolved = path.resolve(folder);
-  fs.accessSync(resolved, fs.constants.R_OK | fs.constants.W_OK);
+  try {
+    fs.accessSync(resolved, fs.constants.R_OK | fs.constants.W_OK);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error('Директория не найдена');
+    }
+    throw new Error('Путь недоступен');
+  }
   memory_state.base_path = resolved;
   memory_state.folder = '';
   memory_state.memory_path = resolved;

--- a/tests/memory.test.js
+++ b/tests/memory.test.js
@@ -1,0 +1,28 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const fs = require('fs');
+const memory = require('../memory');
+
+// Reset memory_state before each test
+function resetState() {
+  memory.memory_state.base_path = '';
+  memory.memory_state.folder = '';
+  memory.memory_state.memory_path = '';
+}
+
+test('setLocalMemoryBasePath throws on missing dir', () => {
+  resetState();
+  const nonExistent = path.join(__dirname, 'no_such_dir');
+  assert.throws(() => {
+    memory.setLocalMemoryBasePath(nonExistent);
+  }, /Директория не найдена/);
+});
+
+test('setMemoryPath throws on missing dir', () => {
+  resetState();
+  const nonExistent = path.join(__dirname, 'no_such_dir');
+  assert.throws(() => {
+    memory.setMemoryPath(nonExistent);
+  }, /Директория не найдена/);
+});


### PR DESCRIPTION
## Summary
- improve error handling for memory path setup
- add tests for bad paths

## Testing
- `node --test` *(fails: Express not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866e88f97f8832399ff93f21b636e57