### PR TITLE
Remove outdated memory mode comment

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -178,10 +178,6 @@ app.post('/set_local_path', (req, res) => {
 });
 
 /**
- * Переключает режим памяти
- */
-
-/**
  * Загружает файл памяти в контекст
  * Запрос: POST /loadMemoryToContext { filename: "file.md" }
  */


### PR DESCRIPTION
## Summary
- clean up `src/api.js` by removing the stale comment about `/switch_memory_mode`

## Testing
- `npm test` *(fails: Subtests cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6866e9970cf88323bffcedc1ce4c416f