### PR TITLE
Add memory save logging

### DIFF
--- a/chat_commands.js
+++ b/chat_commands.js
@@ -47,8 +47,9 @@ function handle_save_local_file(message, userId = 'user') {
   }
   try {
     if (memory.memory_state.memory_path) {
-      const savedPath = memory.writeMemoryFile(filename, content);
-      console.log(`✅ Успешно сохранено: ${savedPath}`);
+      memory.saveMemoryWithIndex(path.join('memory', filename), content)
+        .catch((err) => console.error('saveMemoryWithIndex:', err.message));
+      console.log(`✅ Успешно сохранено: ${filename}`);
     } else {
       console.log('❌ Ошибка: путь памяти не задан');
       return false;
@@ -85,7 +86,8 @@ function handle_save_memory(message, userId = 'user') {
   const content = memory.getCurrentPlan();
   try {
     if (memory.memory_state.memory_path) {
-      memory.writeMemoryFile(filename, content);
+      memory.saveMemoryWithIndex(path.join('memory', filename), content)
+        .catch((err) => console.error('saveMemoryWithIndex:', err.message));
       console.log(`✅ Память сохранена как "${filename}"`);
     } else {
       console.log('❌ Ошибка: путь памяти не задан');

--- a/memory.js
+++ b/memory.js
@@ -263,6 +263,7 @@ async function saveMemoryWithIndex(filename, content, type = 'memory') {
   }
 
   await fs.promises.writeFile(index_path, JSON.stringify(index, null, 2));
+  console.log('[local] Saved memory file:', filename);
   return true;
 }
 

--- a/src/api.js
+++ b/src/api.js
@@ -61,7 +61,8 @@ app.post('/write', (req, res) => {
 
   try {
     console.log('Try to write...')
-    memory.writeMemoryFile(file, content);
+    memory.saveMemoryWithIndex(path.join('memory', file), content)
+      .catch((err) => console.error('saveMemoryWithIndex:', err.message));
     return res.send('File saved successfully');
   } catch (err) {
     return res.status(500).send('Unable to save file');


### PR DESCRIPTION
## Summary
- log a message when saving memory with index
- ensure CLI commands update index
- use saveMemoryWithIndex in write route

## Testing
- `npm test`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_686835fe817c83239bf80dd095d295ae